### PR TITLE
Update nginx and hkweb to use docker hub image

### DIFF
--- a/hkweb/Dockerfile
+++ b/hkweb/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker-nginx-hkweb_alpine:latest
+FROM manik1235/docker-nginx-hkweb_alpine:latest
 # Install Rails
 # begin snippet. From https://github.com/CenturyLinkLabs/alpine-rails/blob/master/Dockerfile
 MAINTAINER CenturyLink Labs <innovationslab@ctl.io>

--- a/nginx/Dockerfile
+++ b/nginx/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker-nginx-hkweb_alpine:latest
+FROM manik1235/docker-nginx-hkweb_alpine:latest
 RUN apk add openssl ca-certificates
 RUN printf "%s%s%s\n" "http://nginx.org/packages/alpine/v" `egrep -o '^[0-9]+\.[0-9]+' /etc/alpine-release` "/main" | tee -a /etc/apk/repositories
 RUN curl -o /tmp/nginx_signing.rsa.pub https://nginx.org/keys/nginx_signing.rsa.pub


### PR DESCRIPTION
This commit updates the nginx and hkweb containers to use the alpine
image on my docker hub account.