### PR TITLE
Replace show page link with url

### DIFF
--- a/hkweb/hkweb/app/views/landings/index.html.erb
+++ b/hkweb/hkweb/app/views/landings/index.html.erb
@@ -12,8 +12,8 @@
     <tbody>
       <% group.landings.find_each do |landing| %>
         <tr>
-          <td><%= link_to landing.name, landing %></td>
-          <td><%= landing.url %></td>
+          <td><%= link_to landing.name, landing.url %></td>
+          <td><%= link_to landing.url, landing.url %></td>
           <td><%= link_to "edit", edit_landing_path(landing) %></td>
           <td><%= link_to 'remove', landing, method: :delete, data: { confirm: 'Are you sure?' } %></td>
         </tr>


### PR DESCRIPTION
In order to allow clickable links, this commit updates the landing index
page to use the assigned urls as the link instead of the show page.