### PR TITLE
Use volume

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 *.swp
 hkweb/hkweb/tmp/**
 hkweb/hkweb/log/**
+hkweb/hkweb/db/dbs/*

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,7 @@ services:
     networks:
       - landingpage
     ports:
-      - "35001:80"
+      - "80:80"
     volumes:
       - "./nginx/volumes/nginx:/volumes"
       - "./nginx/volumes/nginx/conf.d:/etc/nginx/conf.d:ro"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,19 +1,17 @@
-version: '3'
+version: '3.7'
+
 services:
-  alpine:
-    build: .
-    networks:
-      - landingpage
   nginx:
     build: ./nginx
     networks:
       - landingpage
     ports:
-      - "80:80"
+      - "35001:80"
     volumes:
       - "./nginx/volumes/nginx:/volumes"
       - "./nginx/volumes/nginx/conf.d:/etc/nginx/conf.d:ro"
       - "./nginx/volumes/nginx/nginx.conf:/etc/nginx/nginx.conf:ro"
+
   hkweb:
     build: ./hkweb
     networks:
@@ -21,7 +19,15 @@ services:
     ports:
       - "3000:3000"
     volumes:
-      - "./hkweb/hkweb:/rails/hkweb"
+      - type: "bind"
+        source: ./hkweb/hkweb
+        target: /rails/hkweb
+      - type: "volume"
+        source: hkweb_dbs
+        target: /rails/hkweb/db/dbs
 
 networks:
   landingpage:
+
+volumes:
+  hkweb_dbs:

--- a/hkweb/hkweb/config/database.yml
+++ b/hkweb/hkweb/config/database.yml
@@ -11,7 +11,7 @@ default: &default
 
 development:
   <<: *default
-  database: db/development.sqlite3
+  database: db/dbs/development.sqlite3
 
 # Warning: The database defined as "test" will be erased and
 # re-generated from your development database when you run "rake".

--- a/repo-origin
+++ b/repo-origin
@@ -1,0 +1,2 @@
+The main repo for this origin is:
+git@github.com:manik1235/docker-nginx-hkweb.git


### PR DESCRIPTION
In order to persist changes to the database independently of container lifecycles, this commit updates the docker configuration to use volumes instead of bind mounts for the database. As part of this change, a `dbs` folder is created to contain the db, and keep it separately in the volume.

The port is also set to 80 for the nginx server.