### PR TITLE
Add ability to whitelist ips for web console

### DIFF
--- a/hkweb/hkweb/config/environments/development.rb
+++ b/hkweb/hkweb/config/environments/development.rb
@@ -58,4 +58,10 @@ Rails.application.configure do
   # Use an evented file watcher to asynchronously detect changes in source code,
   # routes, locales, etc. This feature depends on the listen gem.
   config.file_watcher = ActiveSupport::EventedFileUpdateChecker
+
+  # Allow specific IP addresses for the web console when developing remotely
+  whitelist = {
+    little_turtle_library: '208.119.150.96',
+  }
+  config.web_console.whitelisted_ips = whitelist[:little_turtle_library]
 end


### PR DESCRIPTION
This commit adds the ability to whitelist specific ips for rendering the
web console. According to the docs, you can only chose an ip or a
network, so I added a hash that allows me to store different ip
addresses I may want to reuse in the future.