### PR TITLE
Improve styles

### DIFF
--- a/hkweb/hkweb/app/assets/stylesheets/landings.scss
+++ b/hkweb/hkweb/app/assets/stylesheets/landings.scss
@@ -2,17 +2,20 @@
 // They will automatically be included in application.css.
 // You can use Sass (SCSS) here: http://sass-lang.com/
 body {
-  background: darkslategrey url(https://images.pexels.com/photos/1020315/pexels-photo-1020315.jpeg?auto=compress&cs=tinysrgb&dpr=2&h=650&w=940) round;
+  background: darkslategrey url(https://images.pexels.com/photos/1020315/pexels-photo-1020315.jpeg?auto=compress&cs=tinysrgb&dpr=2&h=650&w=940) no-repeat center center fixed;
+  max-width: 100%;
 }
 
 a {
   text-decoration: none;
 }
 
-a:link {
-  color: grey;
+a:visited {
+  color: black;
 }
 
 a:hover {
+  background-color: rgba(0, 0, 0, 0);
   color: red;
+  text-decoration: none;
 }

--- a/hkweb/hkweb/app/controllers/landings_controller.rb
+++ b/hkweb/hkweb/app/controllers/landings_controller.rb
@@ -13,7 +13,9 @@ class LandingsController < ApplicationController
 
   # GET /landings/new
   def new
-    @landing = Landing.new
+    group_id = params[:group_id]
+    @landing = Landing.new(group_id: group_id)
+    console
   end
 
   # GET /landings/1/edit

--- a/hkweb/hkweb/app/views/landings/index.html.erb
+++ b/hkweb/hkweb/app/views/landings/index.html.erb
@@ -1,43 +1,39 @@
-<div class="container">
-  <% if notice %>
-    <div class="row">
-      <div class="col-12">
-        <div class="card">
-          <h1 class="card-header">
-            <p id="notice"><%= notice %></p>
-          </h1>
-        </div>
-      </div>
-    </div>
-  <% end %>
-  <div class="row">
-    <div class="col-12">
-      <div class="card">
-        <h2 class="card-header">Utilities</h2>
-        <div class="card-body">
-          <%= link_to 'Add Entry', new_landing_path %>
-        </div>
-      </div>
-    </div>
-  </div>
-  <div class="row">
-    <% @groups.find_each do |group| %>
-      <div class="col-md-4">
-        <div class="card">
-          <h1 class="card-header"><%= group %></h1>
-          <% group.landings.find_each do |landing| %>
-            <div class="card-body">
-              <h3><%= link_to landing.name, landing.url, class: "card-text" %></h3>
-              <%= link_to landing.url, landing.url, class: "card-text" %>
-              &nbsp;
-              <%= link_to icon('fas', 'edit'), edit_landing_path(landing), title: "Edit", alt: "Edit" %>
-              &nbsp;
-              <%= link_to icon('fas', 'trash'), landing, method: :delete, data: { confirm: 'Are you sure?' }, title: "Remove", alt: "Remove" %>
-            </div>
-          <% end %>
+<div class="background-image">
+  <div class="container-fluid">
+    <% if notice %>
+      <div class="row">
+        <div class="col-12">
+          <div class="card mb-1">
+            <h1 class="card-header">
+              <p id="notice"><%= notice %></p>
+            </h1>
+          </div>
         </div>
       </div>
     <% end %>
+    <div class="row">
+      <% @groups.find_each do |group| %>
+        <div class="col-lg-4 col-xs-12">
+          <div class="card mb-1">
+            <h1 class="card-header"><%= group %><span class="float-right"><%= link_to icon('fas', 'plus-square'), new_landing_path(group_id: group.id), class: "text-success" %></span></h1>
+            <% group.landings.find_each do |landing| %>
+              <div class="card-body">
+                <div class="row">
+                  <div class="col-8">
+                    <%= link_to content_tag(:h3, landing.name) + content_tag(:h6, landing.url), landing.url, class: "card-text" %>
+                  </div>
+                  <div class="col-4">
+                    <h4 class="text-nowrap float-right">
+                      <%= link_to icon('fas', 'edit'), edit_landing_path(landing), title: "Edit", alt: "Edit", class: "mx-2" %>
+                      <%= link_to icon('fas', 'trash'), landing, method: :delete, data: { confirm: 'Are you sure?' }, title: "Remove", alt: "Remove", class: "mx-2" %>
+                    </h4>
+                  </div>
+                </div>
+              </div>
+            <% end %>
+          </div>
+        </div>
+      <% end %>
+    </div>
   </div>
 </div>
-<% console %>

--- a/hkweb/hkweb/config/environments/development.rb
+++ b/hkweb/hkweb/config/environments/development.rb
@@ -65,6 +65,7 @@ Rails.application.configure do
     docker_maybe2: '192.168.160.3',
     docker_container: '192.168.144.2',
     e5450: '10.200.129.248',
+    latitude: '10.200.129.252',
   }
   external_locations = {
     little_turtle_library: '208.119.150.96',


### PR DESCRIPTION
This commit improves a lot of the styles on the landings index page.

Buttons are added to each group that allow you to add an item to that
group. It defaults to it's own group, but that is easy to change on the
form.

There are edit and remove icons for each item, and editing the group
will be added in future commits.

The image background is set to cover the entire view, instead of
tiling.